### PR TITLE
Add handlers for textDocument/references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An extension for Telescope that registers handlers for
 - `textDocument/definition`
 - `textDocument/implementation`
 - `textDocument/typeDefinition`
+- `textDocument/references`
 - `textDocument/documentSymbol`
 - `workspace/symbol`
 - `callHierarchy/incomingCalls`

--- a/lua/telescope/_extensions/lsp_handlers.lua
+++ b/lua/telescope/_extensions/lsp_handlers.lua
@@ -202,6 +202,7 @@ return telescope.register_extension({
 		vim.lsp.handlers['textDocument/definition'] = location_handler('LSP Definitions', opts)
 		vim.lsp.handlers['textDocument/implementation'] = location_handler('LSP Implementations', opts)
 		vim.lsp.handlers['textDocument/typeDefinition'] = location_handler('LSP Type Definitions', opts)
+		vim.lsp.handlers['textDocument/references'] = location_handler('LSP References', opts)
 		vim.lsp.handlers['textDocument/documentSymbol'] = symbol_handler('LSP Document Symbols', opts)
 		vim.lsp.handlers['workspace/symbol'] = symbol_handler('LSP Workspace Symbols', opts)
 		vim.lsp.handlers['callHierarchy/incomingCalls'] = call_hierarchy_handler('LSP Incoming Calls', 'from', opts)


### PR DESCRIPTION
Hi, thank you for this plugin!

Please check this PR.
This PR add hanndler for `textDocument/references`.