### PR TITLE
Fix apply edit when codeAction is selected.

### DIFF
--- a/lua/telescope/_extensions/lsp_handlers.lua
+++ b/lua/telescope/_extensions/lsp_handlers.lua
@@ -69,10 +69,13 @@ local function apply_edit_fn(prompt_bufnr)
 		end
 
 		local action = selection.value
-		if action.edit then
-			lsp_util.apply_workspace_edit(action.edit)
-		elseif type(action.command) == 'table' then
-			lsp_buf.execute_command(action.command)
+		if action.edit or type(action.command) == "table" then
+			if action.edit then
+				lsp_util.apply_workspace_edit(action.edit)
+			end
+			if type(action.command) == 'table' then
+				lsp_buf.execute_command(action.command)
+			end
 		else
 			lsp_buf.execute_command(action)
 		end


### PR DESCRIPTION
Hi, gbrlsnchs.
Thank you this plugin.

This PR fix apply_edit when `textDocument/codeAction`.

`textDocument/codeAction` can return either Command[] or CodeAction[].
If it is a CodeAction, it can have either an edit, a command or both.
Edits should be executed first.

See also:
https://github.com/golang/tools/blob/master/gopls/doc/vim.md#neovim-imports
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction