### PR TITLE
Add option jump_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ telescope.setup({
 			location = {
 				telescope = {},
 				no_results_message = 'No references found',
+				jump_type = nil,
 			},
 			symbol = {
 				telescope = {},
@@ -70,6 +71,13 @@ telescope.setup({
 	},
 }
 ```
+
+By default the `location` handler jumps to the location in the current window if there is only one,
+you can change this behavior using option `jump_type`:
+- `jump_type = "never"`: show Telescope picker
+- `jump_type = "tab"`: jump to location in a new tab
+- `jump_type = "split"`: jump to location in a new horizontal split
+- `jump_type = "vsplit"`: jump to location in a new vertical split
 
 #### Disabling specific handlers
 ```lua

--- a/lua/telescope/_extensions/lsp_handlers.lua
+++ b/lua/telescope/_extensions/lsp_handlers.lua
@@ -118,13 +118,18 @@ local function location_handler(prompt_title, opts)
 			return
 		end
 
-		if not vim.tbl_islist(result) then
+		if opts.jump_type ~= "never" and (not vim.tbl_islist(result) or #result == 1) then
+			if vim.tbl_islist(result) then
+				result = result[1]
+			end
+			if opts.jump_type == "tab" then
+				vim.cmd("tabedit")
+			elseif opts.jump_type == "split" then
+				vim.cmd("new")
+			elseif opts.jump_type == "vsplit" then
+				vim.cmd("vnew")
+			end
 			jump_to_location(result)
-			return
-		end
-
-		if #result == 1 then
-			jump_to_location(result[1])
 			return
 		end
 
@@ -207,6 +212,7 @@ return telescope.register_extension({
 			location = {
 				telescope = {},
 				no_results_message = 'No references found',
+				jump_type = nil,
 			},
 			symbol = {
 				telescope = {},


### PR DESCRIPTION
`jump_type` specifies how to jump if there is only one location
- default: jump to location in current window (original behavior)
- `jump_type = "never"`: show Telescope picker
- `jump_type = "tab"`: jump to location in a new tab
- `jump_type = "split"`: jump to location in a new horizontal split
- `jump_type = "vsplit"`: jump to location in a new vertical split

This is similar to <https://github.com/nvim-telescope/telescope.nvim/pull/1077>.