### PR TITLE
Update lsp handler function to new format

### DIFF
--- a/lua/telescope/_extensions/lsp_handlers.lua
+++ b/lua/telescope/_extensions/lsp_handlers.lua
@@ -112,7 +112,7 @@ local function find(prompt_title, items, find_opts)
 end
 
 local function location_handler(prompt_title, opts)
-	return function(_, _, result)
+	return function(_, result, _, _)
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return
@@ -136,7 +136,7 @@ end
 local function symbol_handler(prompt_name, opts)
 	opts = opts or {}
 
-	return function(_, _, result)
+	return function(_, result, _, _)
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return
@@ -148,7 +148,7 @@ local function symbol_handler(prompt_name, opts)
 end
 
 local function call_hierarchy_handler(prompt_name, direction, opts)
-	return function(_, _, result)
+	return function(_, result, _, _)
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return
@@ -172,7 +172,7 @@ local function call_hierarchy_handler(prompt_name, direction, opts)
 end
 
 local function code_action_handler(prompt_title, opts)
-	return function(_, _, result)
+	return function(_, result, _, _)
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return

--- a/lua/telescope/_extensions/lsp_handlers.lua
+++ b/lua/telescope/_extensions/lsp_handlers.lua
@@ -44,7 +44,6 @@ local function jump_fn(prompt_bufnr, action)
 	end
 end
 
-
 local function attach_location_mappings(prompt_bufnr, map)
 	local modes = {'i', 'n'}
 	local keys = {'<CR>', '<C-x>', '<C-v>', '<C-t>'}
@@ -111,8 +110,14 @@ local function find(prompt_title, items, find_opts)
 	}):find()
 end
 
+local function get_correct_result(result1, result2)
+  return type(result1) == 'table' and result1 or result2
+end
+
 local function location_handler(prompt_title, opts)
-	return function(_, result, _, _)
+	return function(_, result1, result2, _)
+    local result = get_correct_result(result1, result2)
+
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return
@@ -136,7 +141,8 @@ end
 local function symbol_handler(prompt_name, opts)
 	opts = opts or {}
 
-	return function(_, result, _, _)
+	return function(_, result1, result2, _)
+    local result = get_correct_result(result1, result2)
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return
@@ -148,7 +154,9 @@ local function symbol_handler(prompt_name, opts)
 end
 
 local function call_hierarchy_handler(prompt_name, direction, opts)
-	return function(_, result, _, _)
+	return function(_, result1, result2, _)
+    local result = get_correct_result(result1, result2)
+
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return
@@ -172,7 +180,9 @@ local function call_hierarchy_handler(prompt_name, direction, opts)
 end
 
 local function code_action_handler(prompt_title, opts)
-	return function(_, result, _, _)
+	return function(_, result1, result2, _)
+    local result = get_correct_result(result1, result2)
+
 		if not result or vim.tbl_isempty(result) then
 			print(opts.no_results_message)
 			return


### PR DESCRIPTION
Since the merging of this Neovim PR the function signature for an LSP handler is slightly different.
https://github.com/neovim/neovim/pull/15504

This PR updates it to the new signature.
There is probably a way to make this backwards compatible but I'll leave that decision to you.