### PR TITLE
fix: support uri

### DIFF
--- a/lua/telescope/_extensions/lsp_handlers.lua
+++ b/lua/telescope/_extensions/lsp_handlers.lua
@@ -34,13 +34,19 @@ local function jump_fn(prompt_bufnr, action)
 			character = selection.col,
 		}
 
+		-- process to uri if filename is not uri
+		local uri = selection.filename
+		if not string.match(uri, "^[^:]+://") then
+			uri = vim.uri_from_fname(selection.filename)
+		end
+
 		jump_to_location({
-			uri = vim.uri_from_fname(selection.filename),
+			uri = uri,
 			range = {
 				start = pos,
 				['end'] = pos,
 			}
-		})
+		}, "utf-8")
 	end
 end
 
@@ -124,12 +130,12 @@ local function location_handler(prompt_title, opts)
 		end
 
 		if not vim.tbl_islist(result) then
-			jump_to_location(result)
+			jump_to_location(result, "utf-8")
 			return
 		end
 
 		if #result == 1 then
-			jump_to_location(result[1])
+			jump_to_location(result[1], "utf-8")
 			return
 		end
 


### PR DESCRIPTION
Support jump to uri location like `jdt://contents/spring-webmvc-4.3.11.RELEASE.jar/org.springframework.web.servlet/DispatcherServlet.class?=music-community-friends-service-cache/%5C/home%5C/fengwk%5C/.m2%5C/repository%5C/org%5C
/springframework%5C/spring-webmvc%5C/4.3.11.RELEASE%5C/spring-webmvc-4.3.11.RELEASE.jar=/maven.pomderived=/true=/=/javadoc_location=/jar:file:%5C/home%5C/fengwk%5C/.m2%5C/repository%5C/org%5C/springfram
ework%5C/spring-webmvc%5C/4.3.11.RELEASE%5C/spring-webmvc-4.3.11.RELEASE-javadoc.jar%5C!%5C/=/=/maven.groupId=/org.springframework=/=/maven.artifactId=/spring-webmvc=/=/maven.version=/4.3.11.RELEASE=/=/
maven.scope=/compile=/=/maven.pomderived=/true=/%3Corg.springframework.web.servlet(DispatcherServlet.class`.

Also, I don't know much about vim api. Maybe there is a better way to replace hard coded "utf-8".